### PR TITLE
All printings sqlite card lookup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 *.db-shm
 *.db-wal
 *.sqlite
+*.sqlite-*
 *.csv
 *Migrations
 cards.json

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 *.db
 *.db-shm
 *.db-wal
+*.sqlite
 *.csv
 *Migrations
 cards.json

--- a/MtgViewer.Tests/Startup.cs
+++ b/MtgViewer.Tests/Startup.cs
@@ -59,7 +59,7 @@ public class Startup
             .AddTransient<TradeValidate>();
 
         services
-            .AddScoped<InMemoryConnection>()
+            .AddScoped<InMemoryConnectionStrings>()
             .AddSingleton<TempFileName>();
 
         _ = config.GetConnectionString("Provider") switch

--- a/MtgViewer.Tests/Utils/InMemoryConnection.cs
+++ b/MtgViewer.Tests/Utils/InMemoryConnection.cs
@@ -1,30 +1,10 @@
 using System;
-using System.Data.Common;
-using System.Threading.Tasks;
-
-using Microsoft.Data.Sqlite;
 
 namespace MtgViewer.Tests.Utils;
 
-public sealed class InMemoryConnection : IAsyncDisposable
+public sealed class InMemoryConnectionStrings
 {
-    private readonly Lazy<SqliteConnection> _connection = new(() =>
-    {
-        var conn = new SqliteConnection("Filename=:memory:");
-        conn.Open();
+    public string Sqlite { get; } = "Filename=:memory:";
 
-        return conn;
-    });
-
-    public DbConnection Connection => _connection.Value;
-
-    public string Database { get; } = "Test-Database-" + Guid.NewGuid();
-
-    public async ValueTask DisposeAsync()
-    {
-        if (_connection.IsValueCreated)
-        {
-            await _connection.Value.DisposeAsync();
-        }
-    }
+    public string InMemory { get; } = "Test-Database-" + Guid.NewGuid();
 }

--- a/MtgViewer.Tests/Utils/TestFactory.cs
+++ b/MtgViewer.Tests/Utils/TestFactory.cs
@@ -24,21 +24,21 @@ public static class TestFactory
 {
     public static void InMemoryDatabase(IServiceProvider provider, DbContextOptionsBuilder options)
     {
-        var inMemory = provider.GetRequiredService<InMemoryConnection>();
+        var connectionStrings = provider.GetRequiredService<InMemoryConnectionStrings>();
 
         options
             .EnableSensitiveDataLogging()
-            .UseInMemoryDatabase(inMemory.Database)
+            .UseInMemoryDatabase(connectionStrings.InMemory)
             .ConfigureWarnings(b => b.Ignore(InMemoryEventId.TransactionIgnoredWarning));
     }
 
     public static void SqliteInMemory(IServiceProvider provider, DbContextOptionsBuilder options)
     {
-        var inMemory = provider.GetRequiredService<InMemoryConnection>();
+        var inMemory = provider.GetRequiredService<InMemoryConnectionStrings>();
 
         options
             .EnableSensitiveDataLogging()
-            .UseSqlite(inMemory.Connection);
+            .UseSqlite(inMemory.Sqlite);
     }
 
     public static UserStore<CardUser> CardUserStore(IServiceProvider provider)

--- a/MtgViewer.Tests/Utils/TestMtgApiQuery.cs
+++ b/MtgViewer.Tests/Utils/TestMtgApiQuery.cs
@@ -43,8 +43,8 @@ public class TestMtgApiQuery : IMtgQuery
     public Task<OffsetList<Card>> SearchAsync(IMtgSearch search, CancellationToken cancel = default)
         => _mtgQuery.SearchAsync(search, cancel);
 
-    public IAsyncEnumerable<Card> CollectionAsync(IEnumerable<string> multiverseIds)
-        => _mtgQuery.CollectionAsync(multiverseIds);
+    public IAsyncEnumerable<Card> CollectionAsync(IEnumerable<string> multiverseIds, CancellationToken cancel = default)
+        => _mtgQuery.CollectionAsync(multiverseIds, cancel);
 
     public Task<Card?> FindAsync(string id, CancellationToken cancel = default)
         => _mtgQuery.FindAsync(id, cancel);

--- a/MtgViewer/Program.cs
+++ b/MtgViewer/Program.cs
@@ -77,7 +77,7 @@ services
 services
     .AddSingleton<ParseTextFilter>()
     .AddScoped<FileCardStorage>()
-    .AddMtgQueries();
+    .AddMtgQueries(config);
 
 if (env.IsDevelopment())
 {

--- a/MtgViewer/Services/Infrastructure/MergeHandler.cs
+++ b/MtgViewer/Services/Infrastructure/MergeHandler.cs
@@ -91,9 +91,7 @@ public class MergeHandler
             .Except(dbCards
                 .Select(c => c.MultiverseId));
 
-        var validCards = _mtgQuery
-            .CollectionAsync(newMultiverseIds)
-            .WithCancellation(cancel);
+        var validCards = _mtgQuery.CollectionAsync(newMultiverseIds, cancel);
 
         // existing cards will be left unmodified, so they don't
         // need to be validated
@@ -226,9 +224,7 @@ public class MergeHandler
 
         if (newMultiverse.Any())
         {
-            var newCards = _mtgQuery
-                .CollectionAsync(newMultiverse)
-                .WithCancellation(cancel);
+            var newCards = _mtgQuery.CollectionAsync(newMultiverse, cancel);
 
             await foreach (var card in newCards)
             {

--- a/MtgViewer/Services/Search/Database/AllPrintingsDbContext.cs
+++ b/MtgViewer/Services/Search/Database/AllPrintingsDbContext.cs
@@ -1,0 +1,19 @@
+﻿using Microsoft.EntityFrameworkCore;
+
+namespace MtgViewer.Services.Search.Database;
+
+public class AllPrintingsDbContext : DbContext
+{
+    public AllPrintingsDbContext(DbContextOptions<AllPrintingsDbContext> options)
+        : base(options)
+    {
+    }
+
+    public virtual DbSet<Card> Cards => Set<Card>();
+    public virtual DbSet<CardIdentifier> CardIdentifiers => Set<CardIdentifier>();
+    public DbSet<Set> Sets => Set<Set>();
+
+    protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+    {
+    }
+}

--- a/MtgViewer/Services/Search/Database/AllPrintingsDbContext.cs
+++ b/MtgViewer/Services/Search/Database/AllPrintingsDbContext.cs
@@ -9,8 +9,10 @@ public class AllPrintingsDbContext : DbContext
     {
     }
 
-    public virtual DbSet<Card> Cards => Set<Card>();
-    public virtual DbSet<CardIdentifier> CardIdentifiers => Set<CardIdentifier>();
+    public DbSet<CardIdentifier> CardIdentifiers => Set<CardIdentifier>();
+
+    public DbSet<Card> Cards => Set<Card>();
+
     public DbSet<Set> Sets => Set<Set>();
 
     protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)

--- a/MtgViewer/Services/Search/Database/Models/Card.cs
+++ b/MtgViewer/Services/Search/Database/Models/Card.cs
@@ -1,0 +1,99 @@
+﻿using System;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+using Microsoft.EntityFrameworkCore;
+
+namespace MtgViewer.Services.Search.Database;
+
+[Table("cards")]
+[Index("Uuid", Name = "cards_uuid")]
+public partial class Card
+{
+    [Key]
+    [Column("uuid", TypeName = "VARCHAR(36)")]
+    public string Uuid { get; set; } = null!;
+
+    [Column("artist")]
+    public string? Artist { get; set; }
+
+    [Column("borderColor")]
+    public string? BorderColor { get; set; }
+
+    [Column("cardParts")]
+    public string? CardParts { get; set; }
+
+    [Column("colorIdentity")]
+    public string? ColorIdentity { get; set; }
+
+    [Column("colors")]
+    public string? Colors { get; set; }
+
+    [Column("defense")]
+    public string? Defense { get; set; }
+
+    [Column("flavorText")]
+    public string? FlavorText { get; set; }
+
+    [Column("isFullArt", TypeName = "BOOLEAN")]
+    public bool? IsFullArt { get; set; }
+
+    [Column("layout")]
+    public string? Layout { get; set; }
+
+    [Column("life")]
+    public string? Life { get; set; }
+
+    [Column("loyalty")]
+    public string? Loyalty { get; set; }
+
+    [Column("manaCost")]
+    public string? ManaCost { get; set; }
+
+    [Column("manaValue", TypeName = "FLOAT")]
+    public float? ManaValue { get; set; }
+
+    [Column("name")]
+    public string? Name { get; set; }
+
+    [Column("number")]
+    public string? Number { get; set; }
+
+    [Column("power")]
+    public string? Power { get; set; }
+
+    [Column("rarity")]
+    public string? Rarity { get; set; }
+
+    [Column("relatedCards")]
+    public string? RelatedCards { get; set; }
+
+    [Column("side")]
+    public string? Side { get; set; }
+
+    [Column("subtypes")]
+    public string? Subtypes { get; set; }
+
+    [Column("supertypes")]
+    public string? Supertypes { get; set; }
+
+    [Column("text")]
+    public string? Text { get; set; }
+
+    [Column("toughness")]
+    public string? Toughness { get; set; }
+
+    [Column("type")]
+    public string? Type { get; set; }
+
+    [Column("types")]
+    public string? Types { get; set; }
+
+    [Column("setCode")]
+    [ForeignKey(nameof(Set))]
+    public string SetCode { get; set; } = string.Empty;
+
+    public Set Set { get; set; } = null!;
+
+    public CardIdentifier CardIdentifier { get; set; } = null!;
+}

--- a/MtgViewer/Services/Search/Database/Models/Card.cs
+++ b/MtgViewer/Services/Search/Database/Models/Card.cs
@@ -14,6 +14,9 @@ public partial class Card
     [Column("uuid", TypeName = "VARCHAR(36)")]
     public string Uuid { get; set; } = null!;
 
+    [ForeignKey(nameof(Uuid))]
+    public CardIdentifier CardIdentifier { get; set; } = null!;
+
     [Column("artist")]
     public string? Artist { get; set; }
 
@@ -90,10 +93,8 @@ public partial class Card
     public string? Types { get; set; }
 
     [Column("setCode")]
-    [ForeignKey(nameof(Set))]
     public string SetCode { get; set; } = string.Empty;
 
+    [ForeignKey(nameof(SetCode))]
     public Set Set { get; set; } = null!;
-
-    public CardIdentifier CardIdentifier { get; set; } = null!;
 }

--- a/MtgViewer/Services/Search/Database/Models/CardIdentifier.cs
+++ b/MtgViewer/Services/Search/Database/Models/CardIdentifier.cs
@@ -1,15 +1,19 @@
 ﻿using System;
+using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 
 using Microsoft.EntityFrameworkCore;
 
 namespace MtgViewer.Services.Search.Database;
 
-[Keyless]
 [Table("cardIdentifiers")]
 [Index("Uuid", Name = "cardIdentifiers_uuid")]
 public partial class CardIdentifier
 {
+    [Key]
+    [Column("uuid")]
+    public string Uuid { get; set; } = string.Empty;
+
     [Column("cardKingdomId")]
     public string? CardKingdomId { get; set; }
 
@@ -39,8 +43,4 @@ public partial class CardIdentifier
 
     [Column("tcgplayerProductId")]
     public string? TcgplayerProductId { get; set; }
-
-    [Column("uuid")]
-    [ForeignKey(nameof(Card.Uuid))]
-    public string Uuid { get; set; } = string.Empty;
 }

--- a/MtgViewer/Services/Search/Database/Models/CardIdentifier.cs
+++ b/MtgViewer/Services/Search/Database/Models/CardIdentifier.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.ComponentModel.DataAnnotations.Schema;
+
+using Microsoft.EntityFrameworkCore;
+
+namespace MtgViewer.Services.Search.Database;
+
+[Keyless]
+[Table("cardIdentifiers")]
+[Index("Uuid", Name = "cardIdentifiers_uuid")]
+public partial class CardIdentifier
+{
+    [Column("cardKingdomId")]
+    public string? CardKingdomId { get; set; }
+
+    [Column("cardsphereId")]
+    public string? CardsphereId { get; set; }
+
+    [Column("mcmId")]
+    public string? McmId { get; set; }
+
+    [Column("mcmMetaId")]
+    public string? McmMetaId { get; set; }
+
+    [Column("mtgArenaId")]
+    public string? MtgArenaId { get; set; }
+
+    [Column("mtgoFoilId")]
+    public string? MtgoFoilId { get; set; }
+
+    [Column("mtgoId")]
+    public string? MtgoId { get; set; }
+
+    [Column("multiverseId")]
+    public string? MultiverseId { get; set; }
+
+    [Column("scryfallId")]
+    public string? ScryfallId { get; set; }
+
+    [Column("tcgplayerProductId")]
+    public string? TcgplayerProductId { get; set; }
+
+    [Column("uuid")]
+    [ForeignKey(nameof(Card.Uuid))]
+    public string Uuid { get; set; } = string.Empty;
+}

--- a/MtgViewer/Services/Search/Database/Models/Set.cs
+++ b/MtgViewer/Services/Search/Database/Models/Set.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+using Microsoft.EntityFrameworkCore;
+
+namespace MtgViewer.Services.Search.Database;
+
+[Table("sets")]
+[Index("Code", IsUnique = true)]
+public partial class Set
+{
+    [Key]
+    [Column("code", TypeName = "VARCHAR(8)")]
+    public string Code { get; set; } = string.Empty;
+
+    [Column("block")]
+    public string? Block { get; set; }
+
+    [Column("name")]
+    public string? Name { get; set; }
+
+    [Column("parentCode")]
+    public string? ParentCode { get; set; }
+
+    [Column("releaseDate")]
+    public string? ReleaseDate { get; set; }
+
+    [Column("type")]
+    public string? Type { get; set; }
+}

--- a/MtgViewer/Services/Search/IMtgQuery.cs
+++ b/MtgViewer/Services/Search/IMtgQuery.cs
@@ -14,7 +14,7 @@ public interface IMtgQuery
 
     Task<OffsetList<Card>> SearchAsync(IMtgSearch search, CancellationToken cancel = default);
 
-    IAsyncEnumerable<Card> CollectionAsync(IEnumerable<string> multiverseIds);
+    IAsyncEnumerable<Card> CollectionAsync(IEnumerable<string> multiverseIds, CancellationToken cancel = default);
 
     Task<Card?> FindAsync(string id, CancellationToken cancel = default);
 }

--- a/MtgViewer/Services/Search/MtgAllPrintings.cs
+++ b/MtgViewer/Services/Search/MtgAllPrintings.cs
@@ -38,7 +38,7 @@ public sealed class MtgAllPrintings : IMtgQuery
     public IAsyncEnumerable<Data.Card> CollectionAsync(IEnumerable<string> multiverseIds, CancellationToken cancel)
     {
         return _dbContext.Cards
-            .Where(c => multiverseIds.Contains(c.CardIdentifier.MultiverseId))
+            .Where(c => c.CardIdentifier.MultiverseId != null && multiverseIds.Contains(c.CardIdentifier.MultiverseId))
             .Include(c => c.CardIdentifier)
             .Include(c => c.Set)
             .AsNoTracking()
@@ -95,6 +95,7 @@ public sealed class MtgAllPrintings : IMtgQuery
         var cards = _dbContext.Cards
             .Include(c => c.CardIdentifier)
             .Include(c => c.Set)
+            .Where(c => c.CardIdentifier.MultiverseId != null)
             .AsQueryable();
 
         if (!string.IsNullOrEmpty(search.Name))

--- a/MtgViewer/Services/Search/MtgAllPrintings.cs
+++ b/MtgViewer/Services/Search/MtgAllPrintings.cs
@@ -354,5 +354,5 @@ public sealed class MtgAllPrintings : IMtgQuery
         return dataCard;
     }
 
-    private static string GetImageUrl(string multiverseId) => $"https://gatherer.wizards.com/Pages/Card/Details.aspx?multiverseid={multiverseId}";
+    private static string GetImageUrl(string multiverseId) => $"https://gatherer.wizards.com/Handlers/Image.ashx?multiverseid={multiverseId}&type=card";
 }

--- a/MtgViewer/Services/Search/MtgAllPrintings.cs
+++ b/MtgViewer/Services/Search/MtgAllPrintings.cs
@@ -110,6 +110,7 @@ public sealed class MtgAllPrintings : IMtgQuery
             .Include(c => c.CardIdentifier)
             .Include(c => c.Set)
             .Where(c => c.CardIdentifier.MultiverseId != null)
+            .AsNoTracking()
             .AsQueryable();
 
         if (!string.IsNullOrEmpty(search.Name))
@@ -240,6 +241,10 @@ public sealed class MtgAllPrintings : IMtgQuery
             .Where(c => c.Layout == card.Layout)
             .Where(c => c.Uuid != card.Uuid)
 
+            .Include(c => c.CardIdentifier)
+            .Include(c => c.Set)
+
+            .AsNoTracking()
             .FirstOrDefaultAsync(cancel);
     }
 

--- a/MtgViewer/Services/Search/MtgAllPrintings.cs
+++ b/MtgViewer/Services/Search/MtgAllPrintings.cs
@@ -1,0 +1,197 @@
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+using EntityFrameworkCore.Paging;
+
+using Microsoft.EntityFrameworkCore;
+
+using MtgViewer.Services.Search.Database;
+
+namespace MtgViewer.Services.Search;
+
+public sealed class MtgAllPrintings : IMtgQuery
+{
+    private const int MaxSize = 100;
+
+    private readonly AllPrintingsDbContext _dbContext;
+    private readonly int _pageSize;
+
+    public MtgAllPrintings(AllPrintingsDbContext dbContext, PageSize pageSize)
+    {
+        _dbContext = dbContext;
+        _pageSize = pageSize.Default;
+    }
+
+    public bool HasFlip(string cardName)
+    {
+        const string faceSplit = "//";
+
+        const StringComparison ordinal = StringComparison.Ordinal;
+
+        return cardName.Contains(faceSplit, ordinal);
+    }
+
+    public IAsyncEnumerable<Data.Card> CollectionAsync(IEnumerable<string> multiverseIds, CancellationToken cancel)
+    {
+        return _dbContext.Cards
+            .Where(c => multiverseIds.Contains(c.CardIdentifier.MultiverseId))
+            .Include(c => c.CardIdentifier)
+            .Include(c => c.Set)
+            .AsNoTracking()
+            .AsAsyncEnumerable()
+            .SelectAwait(c => GetDataCardAsync(c, cancel));
+    }
+
+    public async Task<OffsetList<Data.Card>> SearchAsync(IMtgSearch search, CancellationToken cancel)
+    {
+        ArgumentNullException.ThrowIfNull(search);
+
+        var cardQuery = ApplyFilters(search);
+
+        int pageSize = search.PageSize is > 0 and <= MaxSize
+            ? search.PageSize
+            : _pageSize;
+
+        var cards = await cardQuery
+            .Skip(search.Page * pageSize)
+            .Take(pageSize)
+            .AsAsyncEnumerable()
+            .SelectAwait(c => GetDataCardAsync(c, cancel))
+            .ToListAsync(cancel);
+
+        int totalCount = await cardQuery.CountAsync(cancel);
+
+        var offset = new Offset(search.Page, totalCount, pageSize);
+
+        return new OffsetList<Data.Card>(offset, cards);
+    }
+
+    public async Task<Data.Card?> FindAsync(string id, CancellationToken cancel)
+    {
+        var card = await _dbContext.Cards
+            .Include(c => c.CardIdentifier)
+            .Include(c => c.Set)
+            .AsNoTracking()
+            .FirstOrDefaultAsync(c => c.Uuid == id, cancel);
+
+        if (card is null)
+        {
+            return null;
+        }
+
+        return await GetDataCardAsync(card, cancel);
+    }
+
+    private async ValueTask<Data.Card> GetDataCardAsync(Card card, CancellationToken cancel)
+    {
+    }
+
+    private IQueryable<Card> ApplyFilters(IMtgSearch search)
+    {
+        var cards = _dbContext.Cards
+            .Include(c => c.CardIdentifier)
+            .Include(c => c.Set)
+            .AsQueryable();
+
+        if (!string.IsNullOrEmpty(search.Name))
+        {
+            string name = search.Name.ToUpperInvariant();
+
+            cards = cards.Where(c => c.Name != null && c.Name.ToUpperInvariant().Contains(name));
+        }
+
+        if (!string.IsNullOrEmpty(search.SetName))
+        {
+            string setName = search.SetName.ToUpperInvariant();
+
+            cards = cards.Where(c => c.Set.Name != null && c.Set.Name.ToUpperInvariant().Contains(setName));
+        }
+
+        if (search.ManaValue is int manaValue)
+        {
+            cards = cards.Where(c => c.ManaValue == manaValue);
+        }
+
+        if (search.Colors is not Data.Color.None)
+        {
+            var colors = Data.Symbol.Colors
+                .Where(kv => search.Colors.HasFlag(kv.Key))
+                .Select(kv => kv.Value);
+
+            foreach (string? color in colors)
+            {
+                cards = cards.Where(c => c.Colors != null && c.Colors.Contains(color));
+            }
+        }
+
+        if (!string.IsNullOrEmpty(search.Power))
+        {
+            string power = search.Power.ToUpperInvariant();
+
+            cards = cards.Where(c => c.Power != null && c.Power.ToUpperInvariant().Contains(power));
+        }
+
+        if (!string.IsNullOrEmpty(search.Toughness))
+        {
+            string toughness = search.Toughness.ToUpperInvariant();
+
+            cards = cards.Where(c => c.Toughness != null && c.Toughness.ToUpperInvariant().Contains(toughness));
+        }
+
+        if (!string.IsNullOrEmpty(search.Loyalty))
+        {
+            string loyalty = search.Loyalty.ToUpperInvariant();
+
+            cards = cards.Where(c => c.Loyalty != null && c.Loyalty.ToUpperInvariant().Contains(loyalty));
+        }
+
+        if (search.Rarity is Data.Rarity rarity)
+        {
+            cards = cards.Where(c => c.Rarity == rarity.ToString());
+        }
+
+        if (search.Types is not null)
+        {
+            char[] separator = { ' ', ',' };
+
+            const StringSplitOptions notWhiteSpace = StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries;
+
+            string[] types = search.Types
+                .ToUpperInvariant()
+                .Trim()
+                .Split(separator, notWhiteSpace);
+
+            foreach (string type in types)
+            {
+                cards = cards.Where(c => c.Types != null && c.Types.ToUpperInvariant().Contains(type));
+            }
+        }
+
+        if (!string.IsNullOrEmpty(search.Artist))
+        {
+            string artist = search.Artist.ToUpperInvariant();
+
+            cards = cards.Where(c => c.Artist != null && c.Artist.ToUpperInvariant().Contains(artist));
+        }
+
+        if (!string.IsNullOrEmpty(search.Text))
+        {
+            string text = search.Text.ToUpperInvariant();
+
+            cards = cards.Where(c => c.Text != null && c.Text.ToUpperInvariant().Contains(text));
+        }
+
+        if (!string.IsNullOrEmpty(search.Flavor))
+        {
+            string flavor = search.Flavor.ToUpperInvariant();
+
+            cards = cards.Where(c => c.FlavorText != null && c.FlavorText.ToUpperInvariant().Contains(flavor));
+        }
+
+        return cards;
+    }
+}

--- a/MtgViewer/Services/Search/MtgAllPrintings.cs
+++ b/MtgViewer/Services/Search/MtgAllPrintings.cs
@@ -116,14 +116,14 @@ public sealed class MtgAllPrintings : IMtgQuery
         {
             string name = search.Name.ToUpperInvariant();
 
-            cards = cards.Where(c => c.Name != null && c.Name.ToUpperInvariant().Contains(name));
+            cards = cards.Where(c => c.Name != null && c.Name.ToUpper().Contains(name));
         }
 
         if (!string.IsNullOrEmpty(search.SetName))
         {
             string setName = search.SetName.ToUpperInvariant();
 
-            cards = cards.Where(c => c.Set.Name != null && c.Set.Name.ToUpperInvariant().Contains(setName));
+            cards = cards.Where(c => c.Set.Name != null && c.Set.Name.ToUpper().Contains(setName));
         }
 
         if (search.ManaValue is int manaValue)
@@ -147,21 +147,21 @@ public sealed class MtgAllPrintings : IMtgQuery
         {
             string power = search.Power.ToUpperInvariant();
 
-            cards = cards.Where(c => c.Power != null && c.Power.ToUpperInvariant().Contains(power));
+            cards = cards.Where(c => c.Power != null && c.Power.ToUpper().Contains(power));
         }
 
         if (!string.IsNullOrEmpty(search.Toughness))
         {
             string toughness = search.Toughness.ToUpperInvariant();
 
-            cards = cards.Where(c => c.Toughness != null && c.Toughness.ToUpperInvariant().Contains(toughness));
+            cards = cards.Where(c => c.Toughness != null && c.Toughness.ToUpper().Contains(toughness));
         }
 
         if (!string.IsNullOrEmpty(search.Loyalty))
         {
             string loyalty = search.Loyalty.ToUpperInvariant();
 
-            cards = cards.Where(c => c.Loyalty != null && c.Loyalty.ToUpperInvariant().Contains(loyalty));
+            cards = cards.Where(c => c.Loyalty != null && c.Loyalty.ToUpper().Contains(loyalty));
         }
 
         if (search.Rarity is Data.Rarity rarity)
@@ -182,7 +182,7 @@ public sealed class MtgAllPrintings : IMtgQuery
 
             foreach (string type in types)
             {
-                cards = cards.Where(c => c.Types != null && c.Types.ToUpperInvariant().Contains(type));
+                cards = cards.Where(c => c.Types != null && c.Types.ToUpper().Contains(type));
             }
         }
 
@@ -190,21 +190,21 @@ public sealed class MtgAllPrintings : IMtgQuery
         {
             string artist = search.Artist.ToUpperInvariant();
 
-            cards = cards.Where(c => c.Artist != null && c.Artist.ToUpperInvariant().Contains(artist));
+            cards = cards.Where(c => c.Artist != null && c.Artist.ToUpper().Contains(artist));
         }
 
         if (!string.IsNullOrEmpty(search.Text))
         {
             string text = search.Text.ToUpperInvariant();
 
-            cards = cards.Where(c => c.Text != null && c.Text.ToUpperInvariant().Contains(text));
+            cards = cards.Where(c => c.Text != null && c.Text.ToUpper().Contains(text));
         }
 
         if (!string.IsNullOrEmpty(search.Flavor))
         {
             string flavor = search.Flavor.ToUpperInvariant();
 
-            cards = cards.Where(c => c.FlavorText != null && c.FlavorText.ToUpperInvariant().Contains(flavor));
+            cards = cards.Where(c => c.FlavorText != null && c.FlavorText.ToUpper().Contains(flavor));
         }
 
         return cards;

--- a/MtgViewer/Services/Search/MtgApiQuery.cs
+++ b/MtgViewer/Services/Search/MtgApiQuery.cs
@@ -239,14 +239,13 @@ public sealed class MtgApiQuery : IMtgQuery
 
         while (similarCardsQueue.TryDequeue(out var iCard))
         {
-            bool hasFlipCard = HasFlip(iCard.Name);
+            if (!HasFlip(iCard.Name))
+            {
+                if (Validate(iCard, null) is Card card)
+                {
+                    yield return card;
+                }
 
-            if (!hasFlipCard && Validate(iCard, null) is Card card)
-            {
-                yield return card;
-            }
-            else if (!hasFlipCard)
-            {
                 continue;
             }
 

--- a/MtgViewer/Services/Search/MtgApiQuery.cs
+++ b/MtgViewer/Services/Search/MtgApiQuery.cs
@@ -147,8 +147,8 @@ public sealed class MtgApiQuery : IMtgQuery
             : cards.Where(property, value);
     }
 
-    public IAsyncEnumerable<Card> CollectionAsync(IEnumerable<string> multiverseIds)
-        => BulkSearchAsync(multiverseIds);
+    public IAsyncEnumerable<Card> CollectionAsync(IEnumerable<string> multiverseIds, CancellationToken cancel = default)
+        => BulkSearchAsync(multiverseIds, cancel);
 
     private async IAsyncEnumerable<Card> BulkSearchAsync(
         IEnumerable<string> multiverseIds,

--- a/MtgViewer/Services/Search/MtgApiQuery.cs
+++ b/MtgViewer/Services/Search/MtgApiQuery.cs
@@ -48,6 +48,11 @@ public sealed class MtgApiQuery : IMtgQuery
 
     public bool HasFlip(string cardName)
     {
+        if (string.IsNullOrWhiteSpace(cardName))
+        {
+            return false;
+        }
+
         const string faceSplit = "//";
 
         const StringComparison ordinal = StringComparison.Ordinal;
@@ -55,9 +60,7 @@ public sealed class MtgApiQuery : IMtgQuery
         return cardName.Contains(faceSplit, ordinal);
     }
 
-    public async Task<OffsetList<Card>> SearchAsync(
-        IMtgSearch search,
-        CancellationToken cancel = default)
+    public async Task<OffsetList<Card>> SearchAsync(IMtgSearch search, CancellationToken cancel = default)
     {
         ArgumentNullException.ThrowIfNull(search);
 
@@ -148,7 +151,11 @@ public sealed class MtgApiQuery : IMtgQuery
     }
 
     public IAsyncEnumerable<Card> CollectionAsync(IEnumerable<string> multiverseIds, CancellationToken cancel = default)
-        => BulkSearchAsync(multiverseIds, cancel);
+    {
+        multiverseIds ??= Enumerable.Empty<string>();
+
+        return BulkSearchAsync(multiverseIds, cancel);
+    }
 
     private async IAsyncEnumerable<Card> BulkSearchAsync(
         IEnumerable<string> multiverseIds,

--- a/MtgViewer/Services/Search/PrintingOptions.cs
+++ b/MtgViewer/Services/Search/PrintingOptions.cs
@@ -1,0 +1,8 @@
+namespace MtgViewer.Services.Search;
+
+public class PrintingOptions
+{
+    public bool UseLocal { get; set; }
+
+    public string? FilePath { get; set; }
+}

--- a/MtgViewer/Services/Search/StartupExtensions.cs
+++ b/MtgViewer/Services/Search/StartupExtensions.cs
@@ -18,7 +18,7 @@ public static partial class StartupExtensions
 
         if (options.UseLocal && options.FilePath is not null)
         {
-            services.AddDbContext<AllPrintingsDbContext>(optionsBuilder =>
+            services.AddDbContextFactory<AllPrintingsDbContext>(optionsBuilder =>
             {
                 optionsBuilder.UseSqlite(options.FilePath);
             });

--- a/MtgViewer/Services/Search/StartupExtensions.cs
+++ b/MtgViewer/Services/Search/StartupExtensions.cs
@@ -1,20 +1,40 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+
 using MtgApiManager.Lib.Service;
 
 using MtgViewer.Services.Search;
+using MtgViewer.Services.Search.Database;
 
 namespace Microsoft.Extensions.DependencyInjection;
 
 public static partial class StartupExtensions
 {
-    public static IServiceCollection AddMtgQueries(this IServiceCollection services)
+    public static IServiceCollection AddMtgQueries(this IServiceCollection services, IConfiguration config)
     {
-        services
-            .AddSingleton<IMtgServiceProvider, MtgServiceProvider>()
-            .AddScoped(provider => provider
-                .GetRequiredService<IMtgServiceProvider>()
-                .GetCardService());
+        var options = new PrintingOptions();
 
-        return services
-            .AddScoped<IMtgQuery, MtgApiQuery>();
+        config.GetSection(nameof(PrintingOptions)).Bind(options);
+
+        if (options.UseLocal && options.FilePath is not null)
+        {
+            services.AddDbContext<AllPrintingsDbContext>(optionsBuilder =>
+            {
+                optionsBuilder.UseSqlite(options.FilePath);
+            });
+        }
+        else
+        {
+            services
+                .AddSingleton<IMtgServiceProvider, MtgServiceProvider>()
+                .AddScoped(provider => provider
+                    .GetRequiredService<IMtgServiceProvider>()
+                    .GetCardService());
+
+            services
+                .AddScoped<IMtgQuery, MtgApiQuery>();
+        }
+
+        return services;
     }
 }

--- a/MtgViewer/Services/Search/StartupExtensions.cs
+++ b/MtgViewer/Services/Search/StartupExtensions.cs
@@ -14,27 +14,25 @@ public static partial class StartupExtensions
     {
         var options = new PrintingOptions();
 
-        config.GetSection(nameof(PrintingOptions)).Bind(options);
+        config.Bind(nameof(PrintingOptions), options);
 
         if (options.UseLocal && options.FilePath is not null)
         {
-            services.AddDbContextFactory<AllPrintingsDbContext>(optionsBuilder =>
-            {
-                optionsBuilder.UseSqlite(options.FilePath);
-            });
-
-            services.AddScoped<IMtgQuery, MtgAllPrintings>();
+            services
+                .AddScoped<IMtgQuery, MtgAllPrintings>()
+                .AddDbContextFactory<AllPrintingsDbContext>(optionsBuilder =>
+                {
+                    optionsBuilder.UseSqlite(options.FilePath);
+                });
         }
         else
         {
             services
+                .AddScoped<IMtgQuery, MtgApiQuery>()
                 .AddSingleton<IMtgServiceProvider, MtgServiceProvider>()
                 .AddScoped(provider => provider
                     .GetRequiredService<IMtgServiceProvider>()
                     .GetCardService());
-
-            services
-                .AddScoped<IMtgQuery, MtgApiQuery>();
         }
 
         return services;

--- a/MtgViewer/Services/Search/StartupExtensions.cs
+++ b/MtgViewer/Services/Search/StartupExtensions.cs
@@ -22,6 +22,8 @@ public static partial class StartupExtensions
             {
                 optionsBuilder.UseSqlite(options.FilePath);
             });
+
+            services.AddScoped<IMtgQuery, MtgAllPrintings>();
         }
         else
         {

--- a/MtgViewer/appsettings.Development.json
+++ b/MtgViewer/appsettings.Development.json
@@ -14,5 +14,9 @@
   "SeedSettings": {
     "JsonPath": "cards.json",
     "Seed": 100
+  },
+  "PrintingOptions": {
+    "UseLocal": true,
+    "FilePath": "Filename=Properties/AllPrintings.sqlite"
   }
 }

--- a/MtgViewer/appsettings.json
+++ b/MtgViewer/appsettings.json
@@ -36,9 +36,5 @@
       "Details": 20,
       "Index": 8
     }
-  },
-  "PrintingOptions": {
-    "UseLocal": true,
-    "FilePath": "Filename=Properties/AllPrintings.sqlite"
   }
 }

--- a/MtgViewer/appsettings.json
+++ b/MtgViewer/appsettings.json
@@ -36,5 +36,9 @@
       "Details": 20,
       "Index": 8
     }
+  },
+  "PrintingOptions": {
+    "UseLocal": true,
+    "FilePath": "Filename=Properties/AllPrintings.sqlite"
   }
 }


### PR DESCRIPTION
This pr adds a new way to look up mtg card data. Sqlite queries are ran on a sqlite representation of the all printings data, which is found [here](https://mtgjson.com/downloads/all-files/).

MTGJson does change their data schema from time to time, so updating the data sets might involve db model changes down the road.